### PR TITLE
on first keyboardDidShow height was incorrect

### DIFF
--- a/src/ios/CDVNativeKeyboard.m
+++ b/src/ios/CDVNativeKeyboard.m
@@ -18,8 +18,8 @@ int maxlength;
 {
   // especially useful for the messenger component
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(keyboardWasShown:)
-                                               name:UIKeyboardDidShowNotification object:nil];
+                                           selector:@selector(keyboardWillShown:)
+                                               name:UIKeyboardWillShowNotification object:nil];
 
   // for the textField
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -28,7 +28,7 @@ int maxlength;
 }
 
 // Called when the UIKeyboardDidShowNotification is sent.
-- (void)keyboardWasShown:(NSNotification*)aNotification
+- (void)keyboardWillShown:(NSNotification*)aNotification
 {
   if (tvc != nil) {
     CGSize kbSize = [[[aNotification userInfo] objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;

--- a/src/ios/NKSLKTextViewController.m
+++ b/src/ios/NKSLKTextViewController.m
@@ -57,6 +57,8 @@ BOOL _keepOpenAfterSubmit;
 
 - (void)didChangeKeyboardStatus:(SLKKeyboardStatus)status {
   [super didChangeKeyboardStatus:status];
+  CGFloat height = self.textView.frame.size.height;
+  _lastContentHeight = height;
   if (SLKKeyboardStatusWillShow == status) {
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:@{@"keyboardWillShow":@(YES), @"keyboardHeight":[NSNumber numberWithFloat:_baseKeyboardHeight+_lastContentHeight]}];
     pluginResult.keepCallback = [NSNumber numberWithBool:YES];


### PR DESCRIPTION
I have tested the keyboard in my ionic project with the wkwebview-engine and have determined that **the height at the first keyboardDidShow was not correct**.

I fixed it for ios with the following lines in the pull request.