### PR TITLE
fix for iOS 11 - Keyboard Height is returning 0 in keyboard notification

### DIFF
--- a/src/ios/CDVNativeKeyboard.m
+++ b/src/ios/CDVNativeKeyboard.m
@@ -31,7 +31,7 @@ int maxlength;
 - (void)keyboardWillShow:(NSNotification*)aNotification
 {
   if (tvc != nil) {
-    CGSize kbSize = [[[aNotification userInfo] objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
+    CGSize kbSize = [[[aNotification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue].size;
     [tvc updateKeyboardHeight:kbSize.height];
   }
 }


### PR DESCRIPTION
more details here:
https://stackoverflow.com/questions/45689664/ios-11-keyboard-height-is-returning-0-in-keyboard-notification