### PR TITLE
cordova/android 7.1 and gradle compatibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
 
     <lib-file src="src/android/lib/nativekeyboard.jar" />
 
-    <source-file src="src/android/NativeKeyboard.java" target-dir="app/src/main/java/nl/xservices/plugins/nativekeyboard" />
+    <source-file src="src/android/NativeKeyboard.java" target-dir="src/nl/xservices/plugins/nativekeyboard" />
 
     <source-file src="src/android/res/values/font_awesome.xml" target-dir="app/src/main/res/values" />
     <source-file src="src/android/res/drawable/cursor.xml" target-dir="app/src/main/res/drawable" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
 
     <lib-file src="src/android/lib/nativekeyboard.jar" />
 
-    <source-file src="src/android/NativeKeyboard.java" target-dir="app/src/main/src/nl/xservices/plugins/nativekeyboard" />
+    <source-file src="src/android/NativeKeyboard.java" target-dir="app/src/main/java/nl/xservices/plugins/nativekeyboard" />
 
     <source-file src="src/android/res/values/font_awesome.xml" target-dir="app/src/main/res/values" />
     <source-file src="src/android/res/drawable/cursor.xml" target-dir="app/src/main/res/drawable" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,15 +52,6 @@
 
     <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="res/values" />
 
-    <!-- cordova-android < 7 -->
-    <source-file src="src/android/assets/fonts/fontawesome-webfont.ttf" target-dir="assets/fonts" />
-    <source-file src="src/android/assets/fonts/ionicons.ttf" target-dir="assets/fonts" />
-    <config-file target="res/values/nativekeyboard.xml" parent="/*">
-      <string name="NativeKeyboardPluginLicense">$LIC_ANDROID</string>
-      <string name="NativeKeyboardPluginLicenseAlt">$LICENSE</string>
-    </config-file>
-
-    <!-- cordova-android >= 7 -->
     <source-file src="src/android/assets/fonts/fontawesome-webfont.ttf" target-dir="app/src/main/assets/fonts" />
     <source-file src="src/android/assets/fonts/ionicons.ttf" target-dir="app/src/main/assets/fonts" />
     <config-file target="app/src/main/res/values/nativekeyboard.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -50,11 +50,11 @@
     <source-file src="src/android/res/values/font_awesome.xml" target-dir="res/values" />
     <source-file src="src/android/res/drawable/cursor.xml" target-dir="res/drawable" />
 
-    <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="res/values" />
+    <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="app/src/main/res/values" />
 
     <source-file src="src/android/assets/fonts/fontawesome-webfont.ttf" target-dir="assets/fonts" />
     <source-file src="src/android/assets/fonts/ionicons.ttf" target-dir="assets/fonts" />
-    <config-file target="res/values/nativekeyboard.xml" parent="/*">
+    <config-file target="app/src/main/res/values/nativekeyboard.xml" parent="/*">
       <string name="NativeKeyboardPluginLicense">$LIC_ANDROID</string>
       <string name="NativeKeyboardPluginLicenseAlt">$LICENSE</string>
     </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
   <platform name="android">
     <preference name="LIC_ANDROID" default="TRIAL" />
 
-    <config-file parent="/*" target="res/xml/config.xml">
+    <config-file parent="/*" target="app/src/main/res/xml/config.xml">
       <feature name="NativeKeyboard">
         <param name="android-package" value="nl.xservices.plugins.nativekeyboard.NativeKeyboard" />
         <param name="onload" value="true" />
@@ -45,12 +45,12 @@
 
     <lib-file src="src/android/lib/nativekeyboard.jar" />
 
-    <source-file src="src/android/NativeKeyboard.java" target-dir="src/nl/xservices/plugins/nativekeyboard" />
+    <source-file src="src/android/NativeKeyboard.java" target-dir="app/src/main/src/nl/xservices/plugins/nativekeyboard" />
 
-    <source-file src="src/android/res/values/font_awesome.xml" target-dir="res/values" />
-    <source-file src="src/android/res/drawable/cursor.xml" target-dir="res/drawable" />
+    <source-file src="src/android/res/values/font_awesome.xml" target-dir="app/src/main/res/values" />
+    <source-file src="src/android/res/drawable/cursor.xml" target-dir="app/src/main/res/drawable" />
 
-    <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="res/values" />
+    <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="app/src/main/res/values" />
 
     <source-file src="src/android/assets/fonts/fontawesome-webfont.ttf" target-dir="app/src/main/assets/fonts" />
     <source-file src="src/android/assets/fonts/ionicons.ttf" target-dir="app/src/main/assets/fonts" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
   <platform name="android">
     <preference name="LIC_ANDROID" default="TRIAL" />
 
-    <config-file parent="/*" target="app/src/main/res/xml/config.xml">
+    <config-file parent="/*" target="res/xml/config.xml">
       <feature name="NativeKeyboard">
         <param name="android-package" value="nl.xservices.plugins.nativekeyboard.NativeKeyboard" />
         <param name="onload" value="true" />
@@ -47,14 +47,14 @@
 
     <source-file src="src/android/NativeKeyboard.java" target-dir="src/nl/xservices/plugins/nativekeyboard" />
 
-    <source-file src="src/android/res/values/font_awesome.xml" target-dir="app/src/main/res/values" />
-    <source-file src="src/android/res/drawable/cursor.xml" target-dir="app/src/main/res/drawable" />
+    <source-file src="src/android/res/values/font_awesome.xml" target-dir="res/values" />
+    <source-file src="src/android/res/drawable/cursor.xml" target-dir="res/drawable" />
 
-    <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="app/src/main/res/values" />
+    <source-file src="src/android/res/values/nativekeyboard.xml" target-dir="res/values" />
 
-    <source-file src="src/android/assets/fonts/fontawesome-webfont.ttf" target-dir="app/src/main/assets/fonts" />
-    <source-file src="src/android/assets/fonts/ionicons.ttf" target-dir="app/src/main/assets/fonts" />
-    <config-file target="app/src/main/res/values/nativekeyboard.xml" parent="/*">
+    <source-file src="src/android/assets/fonts/fontawesome-webfont.ttf" target-dir="assets/fonts" />
+    <source-file src="src/android/assets/fonts/ionicons.ttf" target-dir="assets/fonts" />
+    <config-file target="res/values/nativekeyboard.xml" parent="/*">
       <string name="NativeKeyboardPluginLicense">$LIC_ANDROID</string>
       <string name="NativeKeyboardPluginLicenseAlt">$LICENSE</string>
     </config-file>


### PR DESCRIPTION
Current plugin.xml doesn't work on latest cordova due error on FontAwesome copy and license is not filled our correctly. After experimenting I found that this works without problems. No issues on adding plugin, building project and using it.